### PR TITLE
Deprecate v1 SDK → point to idanalyzer/id-analyzer-v2-php-sdk (Composer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
 
+> # ⚠️ DEPRECATED — use the v2 SDK
+> This is the legacy **API v1** PHP SDK (Composer package `idanalyzer/id-analyzer-php-sdk`).
+> It targets the older `api.idanalyzer.com` fleet and is no longer actively maintained.
+>
+> **New projects should use the API v2 SDK:**
+> Composer `idanalyzer/id-analyzer-v2-php-sdk` ·
+> repo [idanalyzer/id-analyzer-v2-php](https://github.com/idanalyzer/id-analyzer-v2-php)
+> (`composer require idanalyzer/id-analyzer-v2-php-sdk`).
+
 # ID Analyzer PHP SDK
 This is a PHP SDK for [ID Analyzer Identity Verification APIs](https://www.idanalyzer.com), though all the APIs can be called with without the SDK using simple HTTP requests as outlined in the [documentation](https://developer.idanalyzer.com), you can use this SDK to accelerate server-side development.
 


### PR DESCRIPTION
Adds a **DEPRECATED** banner to the README pointing new users to the **API v2** SDK (idanalyzer/id-analyzer-v2-php-sdk (Composer)).

This v1 SDK targets the legacy `api.idanalyzer.com` fleet and is no longer actively maintained. README-only change.

Follow-ups (need registry credentials / your action): registry-level deprecation and archiving this GitHub repo after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)